### PR TITLE
Cleanup: remove commented-out Mantis GitHub link from HeaderContent (#47)

### DIFF
--- a/src/layout/Dashboard/Header/HeaderContent/index.jsx
+++ b/src/layout/Dashboard/Header/HeaderContent/index.jsx
@@ -1,30 +1,5 @@
-// ==============================|| HEADER - CONTENT ||============================== //
-
 import Profile from "./Profile";
 
 export default function HeaderContent() {
-  // const downLG = useMediaQuery((theme) => theme.breakpoints.down("lg"));
-
-  return (
-    <>
-      {/*{!downLG && <Search />}*/}
-      {/*{downLG && <Box sx={{ width: '100%', ml: 1 }} />}*/}
-      {/*<IconButton*/}
-      {/*  component={Link}*/}
-      {/*  href="https://github.com/codedthemes/mantis-free-react-admin-template"*/}
-      {/*  target="_blank"*/}
-      {/*  disableRipple*/}
-      {/*  color="secondary"*/}
-      {/*  title="Download Free Version"*/}
-      {/*  sx={{ color: 'text.primary', bgcolor: 'grey.100' }}*/}
-      {/*>*/}
-      {/*  <GithubOutlined />*/}
-      {/*</IconButton>*/}
-
-      {/*<Notification />*/}
-      <Profile />
-      {/*{!downLG && <Profile />}*/}
-      {/*{downLG && <MobileSection />}*/}
-    </>
-  );
+  return <Profile />;
 }


### PR DESCRIPTION
## Summary
- Removes all commented-out code from `HeaderContent/index.jsx`: the Mantis GitHub `IconButton`, `Search`, `MobileSection`, `Notification` JSX blocks, and the `downLG` / `useMediaQuery` dead variable
- File reduced to its active form: import `Profile` and render it

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] No references to `codedthemes`, `GithubOutlined`, `mantis-free-react-admin-template` remain in the file

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)