### PR TITLE
Branding: replace codedthemes links in AuthFooter with Yaba copyright (#49)

### DIFF
--- a/src/components/cards/AuthFooter.jsx
+++ b/src/components/cards/AuthFooter.jsx
@@ -1,70 +1,12 @@
-// material-ui
 import Container from "@mui/material/Container";
-import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
-import Stack from "@mui/material/Stack";
-
-// ==============================|| FOOTER - AUTHENTICATION ||============================== //
 
 export default function AuthFooter() {
   return (
     <Container maxWidth="xl">
-      <Stack
-        direction={{ xs: "column", sm: "row" }}
-        justifyContent={{ xs: "center", sm: "space-between" }}
-        spacing={2}
-        textAlign={{ xs: "center", sm: "inherit" }}
-      >
-        <Typography variant="subtitle2" color="secondary">
-          This site is protected by{" "}
-          <Typography
-            component={Link}
-            variant="subtitle2"
-            href="#mantis-privacy"
-            target="_blank"
-            underline="hover"
-          >
-            Privacy Policy
-          </Typography>
-        </Typography>
-
-        <Stack
-          direction={{ xs: "column", sm: "row" }}
-          spacing={{ xs: 1, sm: 3 }}
-          textAlign={{ xs: "center", sm: "inherit" }}
-        >
-          <Typography
-            variant="subtitle2"
-            color="secondary"
-            component={Link}
-            href="https://codedthemes.com"
-            target="_blank"
-            underline="hover"
-          >
-            Terms and Conditions
-          </Typography>
-          <Typography
-            variant="subtitle2"
-            color="secondary"
-            component={Link}
-            href="https://codedthemes.com"
-            target="_blank"
-            underline="hover"
-          >
-            Privacy Policy
-          </Typography>
-          <Typography
-            variant="subtitle2"
-            color="secondary"
-            component={Link}
-            href="https://codedthemes.com"
-            target="_blank"
-            underline="hover"
-          >
-            CA Privacy Notice
-          </Typography>
-        </Stack>
-      </Stack>
+      <Typography variant="subtitle2" color="secondary" align="center">
+        © {new Date().getFullYear()} Yaba
+      </Typography>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- Removes all `codedthemes.com` links (Terms, Privacy, CA Privacy Notice) and the `#mantis-privacy` anchor
- Replaces the entire footer with a single `© {year} Yaba` copyright line
- Removes now-unused `Link`, `Stack` imports

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] No references to `codedthemes` or `mantis-privacy` remain in the file

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)