### PR TITLE
Design: swap color palette to Muted Teal (#50)

### DIFF
--- a/src/themes/palette.js
+++ b/src/themes/palette.js
@@ -9,8 +9,21 @@ import ThemeOption from "./theme";
 
 // ==============================|| DEFAULT THEME - PALETTE ||============================== //
 
+const teal = [
+  "#e6f7f5",
+  "#ccefec",
+  "#99dfda",
+  "#5eada6",
+  "#2d9089",
+  "#0f766e",
+  "#0d5e57",
+  "#0a4a44",
+  "#083b37",
+  "#052921",
+];
+
 export default function Palette(mode, presetColor) {
-  const colors = presetPalettes;
+  const colors = { ...presetPalettes, teal };
 
   let greyPrimary = [
     "#ffffff",

--- a/src/themes/theme/index.js
+++ b/src/themes/theme/index.js
@@ -1,7 +1,7 @@
 // ==============================|| PRESET THEME - THEME SELECTOR ||============================== //
 
 export default function Theme(colors) {
-  const { blue, red, gold, cyan, green, grey } = colors;
+  const { teal, red, gold, cyan, green, grey } = colors;
   const greyColors = {
     0: grey[0],
     50: grey[1],
@@ -25,16 +25,16 @@ export default function Theme(colors) {
 
   return {
     primary: {
-      lighter: blue[0],
-      100: blue[1],
-      200: blue[2],
-      light: blue[3],
-      400: blue[4],
-      main: blue[5],
-      dark: blue[6],
-      700: blue[7],
-      darker: blue[8],
-      900: blue[9],
+      lighter: teal[0],
+      100: teal[1],
+      200: teal[2],
+      light: teal[3],
+      400: teal[4],
+      main: teal[5],
+      dark: teal[6],
+      700: teal[7],
+      darker: teal[8],
+      900: teal[9],
       contrastText,
     },
     secondary: {


### PR DESCRIPTION
## Summary
- Defines a custom 10-stop teal ramp in `palette.js` (no longer relying on `@ant-design/colors` blue for primary)
- Updates `theme/index.js` to use `teal` instead of `blue` for all primary color tokens
- `@ant-design/colors` is still used for semantic colors (error/warning/info/success)

## Teal ramp
| Token | Value |
|-------|-------|
| lighter (0) | `#e6f7f5` |
| light (3) | `#5eada6` |
| **main (5)** | **`#0f766e`** |
| dark (6) | `#0d5e57` |
| darker (8) | `#083b37` |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] No MUI theme warnings (all primary tokens defined)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)