### PR TITLE
Design: lighten typography scale (#52)

### DIFF
--- a/src/themes/typography.js
+++ b/src/themes/typography.js
@@ -9,28 +9,31 @@ export default function Typography(fontFamily) {
     fontWeightMedium: 500,
     fontWeightBold: 600,
     h1: {
-      fontWeight: 600,
-      fontSize: "2.375rem",
-      lineHeight: 1.21,
+      fontWeight: 500,
+      fontSize: "2rem",
+      lineHeight: 1.25,
+      letterSpacing: "-0.02em",
     },
     h2: {
-      fontWeight: 600,
-      fontSize: "1.875rem",
-      lineHeight: 1.27,
+      fontWeight: 500,
+      fontSize: "1.625rem",
+      lineHeight: 1.3,
+      letterSpacing: "-0.015em",
     },
     h3: {
-      fontWeight: 600,
-      fontSize: "1.5rem",
-      lineHeight: 1.33,
+      fontWeight: 500,
+      fontSize: "1.375rem",
+      lineHeight: 1.35,
+      letterSpacing: "-0.01em",
     },
     h4: {
-      fontWeight: 600,
-      fontSize: "1.25rem",
+      fontWeight: 500,
+      fontSize: "1.125rem",
       lineHeight: 1.4,
     },
     h5: {
-      fontWeight: 600,
-      fontSize: "1rem",
+      fontWeight: 500,
+      fontSize: "0.9375rem",
       lineHeight: 1.5,
     },
     h6: {
@@ -45,7 +48,7 @@ export default function Typography(fontFamily) {
     },
     body1: {
       fontSize: "0.875rem",
-      lineHeight: 1.57,
+      lineHeight: 1.6,
     },
     body2: {
       fontSize: "0.75rem",
@@ -53,7 +56,7 @@ export default function Typography(fontFamily) {
     },
     subtitle1: {
       fontSize: "0.875rem",
-      fontWeight: 600,
+      fontWeight: 500,
       lineHeight: 1.57,
     },
     subtitle2: {


### PR DESCRIPTION
## Summary
- Reduces h1–h5 `fontWeight` from 600 → 500 (less heavy, more refined)
- Trims heading `fontSize`: h1 2.375rem → 2rem, h2 1.875rem → 1.625rem, h3 1.5rem → 1.375rem, h4 1.25rem → 1.125rem, h5 1rem → 0.9375rem
- Adds negative `letterSpacing` to h1–h3 (-0.02em / -0.015em / -0.01em) for a tighter, editorial feel
- `subtitle1` weight 600 → 500 for consistency
- Slightly increased body1 `lineHeight` 1.57 → 1.6 for better readability

## Before / After
| Level | Before | After |
|-------|--------|-------|
| h1 | 600 / 2.375rem | 500 / 2rem / -0.02em |
| h2 | 600 / 1.875rem | 500 / 1.625rem / -0.015em |
| h3 | 600 / 1.5rem | 500 / 1.375rem / -0.01em |
| h4 | 600 / 1.25rem | 500 / 1.125rem |
| h5 | 600 / 1rem | 500 / 0.9375rem |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)