### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dist
 .idea
 graphql.config.yml
 /dist.tar.gz
+.worktrees/


### PR DESCRIPTION
## Summary
- Adds `.worktrees/` to `.gitignore` so worktree directories created by the dev-pipeline skill don't appear as untracked files

## Why
The dev-pipeline skill now places worktrees at `<repo_root>/.worktrees/<branch-name>` (see wenbenz/dot-claude#12). Without this entry they would show up in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)