### PR TITLE
chore: ignore local Claude config and ticket artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 graphql.config.yml
 /dist.tar.gz
 .worktrees/
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.tickets/


### PR DESCRIPTION
## Summary
- Ignore `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` (personal local config, not shareable)
- Ignore `.tickets/` (generated artifacts from plan-tickets skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)