### PR TITLE
Branding: replace Mantis favicon and page title with Yaba (#63, #64)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Mantis is react free admin template build using Vite" />
+    <meta name="description" content="Yaba - personal finance management dashboard" />
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <title>Mantis React Admin Dashboard</title>
+    <title>Yaba</title>
 
     <!-- this is to resolve issue in old safari browser in tablet -->
     <script src="https://cdn.jsdelivr.net/npm/resize-observer-polyfill@1.5.1/dist/ResizeObserver.min.js"></script>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="8" fill="#008080"/>
+  <path d="M9.5 8.5L16 16.5L22.5 8.5M16 16.5V23.5" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- Replace `favicon.svg` with the Yaba Y mark (teal rounded square, matching `LogoMain.jsx` from #48)
- Update `<title>` from `"Mantis React Admin Dashboard"` to `"Yaba"`
- Update meta description to remove Mantis reference

## Test plan
- [ ] Browser tab shows Yaba favicon (teal Y icon)
- [ ] Browser tab title shows "Yaba"
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds

Closes #63
Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)