### PR TITLE
chore: remove empty version chip from logo

### DIFF
--- a/src/components/logo/index.jsx
+++ b/src/components/logo/index.jsx
@@ -3,8 +3,6 @@ import { Link } from "react-router-dom";
 
 // material-ui
 import { ButtonBase } from "@mui/material";
-import Stack from "@mui/material/Stack";
-import Chip from "@mui/material/Chip";
 
 // project import
 import Logo from "./LogoMain";
@@ -20,22 +18,7 @@ const LogoSection = ({ sx, to }) => {
       to={!to ? config.defaultPath : to}
       sx={sx}
     >
-      <Stack direction="row" spacing={1} alignItems="center">
-        <Logo />
-        <Chip
-          label={import.meta.env.VITE_APP_VERSION}
-          variant="outlined"
-          size="small"
-          color="secondary"
-          sx={{
-            mt: 0.5,
-            ml: 1,
-            fontSize: "0.725rem",
-            height: 20,
-            "& .MuiChip-label": { px: 0.5 },
-          }}
-        />
-      </Stack>
+      <Logo />
     </ButtonBase>
   );
 };


### PR DESCRIPTION
## Summary

- Remove the `Chip` component next to the logo — `VITE_APP_VERSION` is never set, so it renders as an empty pill

## Test plan

- [ ] Logo displays without the empty box beside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)