### PR TITLE
feat: add Terms of Service and Privacy Policy pages

### DIFF
--- a/src/pages/authentication/auth-forms/AuthRegister.jsx
+++ b/src/pages/authentication/auth-forms/AuthRegister.jsx
@@ -182,11 +182,11 @@ export default function AuthRegister() {
               <Grid item xs={12}>
                 <Typography variant="body2">
                   By Signing up, you agree to our &nbsp;
-                  <Link variant="subtitle2" component={RouterLink} to="#">
+                  <Link variant="subtitle2" component={RouterLink} to="/terms">
                     Terms of Service
                   </Link>
                   &nbsp; and &nbsp;
-                  <Link variant="subtitle2" component={RouterLink} to="#">
+                  <Link variant="subtitle2" component={RouterLink} to="/privacy">
                     Privacy Policy
                   </Link>
                 </Typography>

--- a/src/pages/privacy/index.jsx
+++ b/src/pages/privacy/index.jsx
@@ -1,0 +1,84 @@
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+import { Link as RouterLink } from "react-router-dom";
+import Link from "@mui/material/Link";
+
+import Logo from "components/logo";
+
+export default function PrivacyPolicy() {
+  return (
+    <Box sx={{ minHeight: "100vh", bgcolor: "background.default", py: 6 }}>
+      <Container maxWidth="md">
+        <Box sx={{ mb: 4 }}>
+          <Logo />
+        </Box>
+
+        <Typography variant="h2" gutterBottom>
+          Privacy Policy
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Last updated: April 2026
+        </Typography>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="h5" gutterBottom>
+          1. Self-Hosted by Design
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Yaba runs entirely on your own server. Your financial data never
+          leaves your infrastructure. We have no servers, no cloud storage, and
+          no access to anything you enter into Yaba.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom>
+          2. No Data Sharing
+        </Typography>
+        <Typography variant="body1" paragraph>
+          We do not collect, sell, rent, or share your personal information or
+          financial data with any third party — ever. There are no analytics,
+          no telemetry, and no tracking of any kind built into Yaba.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom>
+          3. Data You Enter
+        </Typography>
+        <Typography variant="body1" paragraph>
+          All data you enter — budgets, transactions, payment methods — is
+          stored in your own database. You own your data entirely. Deleting
+          your instance permanently removes all of it.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom>
+          4. Authentication
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Credentials are stored in your own database and are never transmitted
+          to any external service. Use a strong password and secure your server
+          accordingly.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom>
+          5. Changes to This Policy
+        </Typography>
+        <Typography variant="body1" paragraph>
+          If this policy changes, the updated version will be available at this
+          URL. We will not make changes that affect how your data is handled
+          without updating this document.
+        </Typography>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="body2" color="text.secondary">
+          Also read our{" "}
+          <Link component={RouterLink} to="/terms">
+            Terms of Service
+          </Link>
+          .
+        </Typography>
+      </Container>
+    </Box>
+  );
+}

--- a/src/pages/terms/index.jsx
+++ b/src/pages/terms/index.jsx
@@ -30,8 +30,7 @@ export default function TermsOfService() {
         <Typography variant="body1" paragraph>
           Yaba is a self-hosted personal finance tool for tracking budgets,
           transactions, and payment methods. You run Yaba on your own
-          infrastructure — Anthropic has no access to your data or your
-          instance.
+          infrastructure — no one else has access to your data or your instance.
         </Typography>
 
         <Typography variant="h5" gutterBottom>

--- a/src/pages/terms/index.jsx
+++ b/src/pages/terms/index.jsx
@@ -1,0 +1,75 @@
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+import { Link as RouterLink } from "react-router-dom";
+import Link from "@mui/material/Link";
+
+import Logo from "components/logo";
+
+export default function TermsOfService() {
+  return (
+    <Box sx={{ minHeight: "100vh", bgcolor: "background.default", py: 6 }}>
+      <Container maxWidth="md">
+        <Box sx={{ mb: 4 }}>
+          <Logo />
+        </Box>
+
+        <Typography variant="h2" gutterBottom>
+          Terms of Service
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Last updated: April 2026
+        </Typography>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="h5" gutterBottom>
+          1. About Yaba
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Yaba is a self-hosted personal finance tool for tracking budgets,
+          transactions, and payment methods. You run Yaba on your own
+          infrastructure — Anthropic has no access to your data or your
+          instance.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom>
+          2. Your Responsibilities
+        </Typography>
+        <Typography variant="body1" paragraph>
+          You are responsible for maintaining your own server, keeping your
+          software up to date, and securing access to your instance. Do not
+          share your credentials with others.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom>
+          3. Acceptable Use
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Yaba is intended for personal finance management. Use it to track
+          your own finances. Do not use it to process data you are not
+          authorized to handle.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom>
+          4. Changes to These Terms
+        </Typography>
+        <Typography variant="body1" paragraph>
+          These terms may be updated from time to time. Continued use of Yaba
+          after changes constitutes acceptance of the updated terms.
+        </Typography>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="body2" color="text.secondary">
+          Questions?{" "}
+          <Link component={RouterLink} to="/privacy">
+            Read our Privacy Policy
+          </Link>
+          .
+        </Typography>
+      </Container>
+    </Box>
+  );
+}

--- a/src/pages/terms/index.jsx
+++ b/src/pages/terms/index.jsx
@@ -59,6 +59,15 @@ export default function TermsOfService() {
           after changes constitutes acceptance of the updated terms.
         </Typography>
 
+        <Typography variant="h5" gutterBottom>
+          5. Provided As-Is
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Yaba is provided as-is, without warranty of any kind. Use it at your
+          own risk. You are responsible for your data, your server, and any
+          consequences of using the software.
+        </Typography>
+
         <Divider sx={{ my: 3 }} />
 
         <Typography variant="body2" color="text.secondary">

--- a/src/routes/LoginRoutes.jsx
+++ b/src/routes/LoginRoutes.jsx
@@ -9,6 +9,8 @@ const AuthLogin = Loadable(lazy(() => import("pages/authentication/login")));
 const AuthRegister = Loadable(
   lazy(() => import("pages/authentication/register")),
 );
+const TermsOfService = Loadable(lazy(() => import("pages/terms")));
+const PrivacyPolicy = Loadable(lazy(() => import("pages/privacy")));
 
 // ==============================|| AUTH ROUTING ||============================== //
 
@@ -23,6 +25,14 @@ const LoginRoutes = {
     {
       path: "/register",
       element: <AuthRegister />,
+    },
+    {
+      path: "/terms",
+      element: <TermsOfService />,
+    },
+    {
+      path: "/privacy",
+      element: <PrivacyPolicy />,
     },
   ],
 };


### PR DESCRIPTION
Closes #68, closes #69

## Summary

- New static page at `/terms` — describes Yaba as a self-hosted tool, acceptable use, no liability language
- New static page at `/privacy` — explicit no data sharing, no telemetry, no third-party access
- Fix broken `to="#"` links in the register form — now point to `/terms` and `/privacy`
- Both pages use `MinimalLayout` via `LoginRoutes`

## Test plan

- [ ] `/terms` renders without errors
- [ ] `/privacy` renders without errors
- [ ] Links in register form navigate to correct pages
- [ ] Logo on each page links back to the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)