### PR TITLE
fix: update Apollo Client v4 imports

### DIFF
--- a/src/api/graph.jsx
+++ b/src/api/graph.jsx
@@ -1,4 +1,5 @@
-import { gql, useMutation, useQuery } from "@apollo/client";
+import { gql } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client/react";
 
 export function useBudgets(count) {
   return useQuery(LIST_BUDGETS, {

--- a/src/components/FileUpload.jsx
+++ b/src/components/FileUpload.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Box, Button, Typography } from "@mui/material";
 import axios from "axios";
-import { useApolloClient } from "@apollo/client";
+import { useApolloClient } from "@apollo/client/react";
 import { Stack } from "@mui/system";
 
 const MAX_FILE_SIZE_MB = 1;

--- a/src/layout/Dashboard/index.jsx
+++ b/src/layout/Dashboard/index.jsx
@@ -18,10 +18,10 @@ import { handlerDrawerOpen, useGetMenuMaster } from "api/menu";
 // apollo client
 import {
     ApolloClient,
-    ApolloProvider,
     createHttpLink, from,
     InMemoryCache,
 } from "@apollo/client";
+import { ApolloProvider } from "@apollo/client/react";
 import axios from "axios";
 import {onError} from "@apollo/client/link/error";
 

--- a/src/pages/browse/CreateCardDialogue.jsx
+++ b/src/pages/browse/CreateCardDialogue.jsx
@@ -1,5 +1,6 @@
 import {useState} from 'react';
-import {gql, useMutation} from '@apollo/client';
+import {gql} from '@apollo/client';
+import {useMutation} from '@apollo/client/react';
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Stack, TextField,} from '@mui/material';
 import {DeleteOutlined} from '@ant-design/icons';
 import {Autocomplete} from "@mui/lab";

--- a/src/pages/dashboard/CategoryChart.jsx
+++ b/src/pages/dashboard/CategoryChart.jsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import ReactApexChart from "react-apexcharts";
 import { AGGREGATE_EXPENDITURES, useBudgets } from "../../api/graph";
 import { useDateRange } from "../../components/DateRangeProvider";
-import { useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
 import {dateDiff, dateString} from "../../utils/dates";
 import {useTheme} from "@mui/material/styles";
 

--- a/src/pages/dashboard/SpendingChart.jsx
+++ b/src/pages/dashboard/SpendingChart.jsx
@@ -4,7 +4,7 @@ import {useMemo, useState} from "react";
 import ReactApexChart from "react-apexcharts";
 import {AGGREGATE_EXPENDITURES, useBudgets} from "../../api/graph";
 import {useDateRange} from "../../components/DateRangeProvider";
-import {useQuery} from "@apollo/client";
+import {useQuery} from "@apollo/client/react";
 import {dateString} from "../../utils/dates";
 import {adjustBudgetForSpan, calculateSpan} from "../../utils/expense";
 

--- a/src/pages/expenditure/RecentTransactionsTable.jsx
+++ b/src/pages/expenditure/RecentTransactionsTable.jsx
@@ -14,7 +14,7 @@ import {useMemo, useState} from "react";
 import Button from "@mui/material/Button";
 import {Stack} from "@mui/system";
 import Typography from "@mui/material/Typography";
-import {useQuery} from "@apollo/client";
+import {useQuery} from "@apollo/client/react";
 import {RECENT_EXPENDITURES, usePaymentMethodNames} from "../../api/graph";
 import Divider from "@mui/material/Divider";
 import {RecentTransactionsTableHeader} from "./TableHeaders";

--- a/src/pages/payment-methods/EditPaymentMethodDialogue.jsx
+++ b/src/pages/payment-methods/EditPaymentMethodDialogue.jsx
@@ -5,7 +5,7 @@ import Box from "@mui/material/Box";
 import {UPDATE_PAYMENT_METHOD, GET_PAYMENT_METHODS, useRewardCards} from "../../api/graph";
 import Typography from "@mui/material/Typography";
 import SearchOutlined from "@ant-design/icons/SearchOutlined";
-import {useMutation} from "@apollo/client";
+import {useMutation} from "@apollo/client/react";
 
 export default function EditPaymentMethodDialog({ open, onClose, method }) {
     const NULL_UUID = "00000000-0000-0000-0000-000000000000";


### PR DESCRIPTION
## Summary
- Apollo Client v4 moved React hooks (`useQuery`, `useMutation`, `useApolloClient`) and `ApolloProvider` from `@apollo/client` to `@apollo/client/react`
- This caused the Docker CI build to fail with `MISSING_EXPORT` errors during `vite build`
- Updated all 8 affected files to import from the correct subpath

## Test plan
- [ ] `yarn build` succeeds without MISSING_EXPORT errors
- [ ] App loads and GraphQL queries/mutations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)