### PR TITLE
fix: add rxjs dependency for Apollo Client v4 error link

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-number-format": "^5.3.3",
     "react-router": "^6.22.3",
     "react-router-dom": "^6.22.3",
+    "rxjs": "^7.8.2",
     "simplebar-react": "^3.2.4",
     "slick-carousel": "^1.8.1",
     "swr": "^2.2.5",
@@ -87,14 +88,12 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.2",
-    "jsdom": "^29.0.0",
-    "vitest": "^4.0.0",
     "@babel/core": "^7.24.0",
     "@babel/eslint-parser": "^7.23.10",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-config-react-app": "^7.0.1",
@@ -104,7 +103,9 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "jsdom": "^29.0.0",
     "prettier": "^3.2.5",
-    "react-error-overlay": "6.1.0"
+    "react-error-overlay": "6.1.0",
+    "vitest": "^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5135,6 +5135,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-array-concat@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz#c9e54ec4f603b0bbb8e7e5007a5ee7aecd1538c3"


### PR DESCRIPTION
## Summary
- `@apollo/client/link/error` requires `rxjs` as a peer dependency in v4
- Without it, `vite build` fails: `Rolldown failed to resolve import "rxjs"`
- Validated locally: `yarn build` succeeds after this change

## Test plan
- [x] `yarn build` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)